### PR TITLE
Feature/#61 상세화면 연결 및 프로필 이름 변경 화면 구현

### DIFF
--- a/Streamify.xcodeproj/project.pbxproj
+++ b/Streamify.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		D03737C42D8C33CD006CED4A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D03737BA2D8C33CD006CED4A /* Assets.xcassets */; };
 		D03737C62D8C33CD006CED4A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D03737BD2D8C33CD006CED4A /* LaunchScreen.storyboard */; };
 		D03737DE2D8C34ED006CED4A /* empty3 in Resources */ = {isa = PBXBuildFile; fileRef = D03737DD2D8C34ED006CED4A /* empty3 */; };
+		D09726392D918B5E00E92726 /* ModifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09726382D918B5E00E92726 /* ModifyViewController.swift */; };
 		D09E0DBF2D8C3748004EEC6C /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09E0DBE2D8C3748004EEC6C /* BaseView.swift */; };
 		D09E0DC12D8C3763004EEC6C /* BaseCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09E0DC02D8C3763004EEC6C /* BaseCollectionViewCell.swift */; };
 		D09E0E552D8C3805004EEC6C /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09E0E542D8C3805004EEC6C /* BaseTableViewCell.swift */; };
@@ -185,6 +186,7 @@
 		D03737BE2D8C33CD006CED4A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		D03737BF2D8C33CD006CED4A /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		D03737DD2D8C34ED006CED4A /* empty3 */ = {isa = PBXFileReference; lastKnownFileType = text; path = empty3; sourceTree = "<group>"; };
+		D09726382D918B5E00E92726 /* ModifyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyViewController.swift; sourceTree = "<group>"; };
 		D09E0DBE2D8C3748004EEC6C /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
 		D09E0DC02D8C3763004EEC6C /* BaseCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionViewCell.swift; sourceTree = "<group>"; };
 		D09E0E542D8C3805004EEC6C /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
@@ -284,14 +286,6 @@
 				3EE1E8662D90D1AF00681B6B /* SearchCollectionViewCell.swift */,
 			);
 			path = View;
-			sourceTree = "<group>";
-		};
-		3EE1E85C2D8F01C700681B6B /* ViewModel */ = {
-			isa = PBXGroup;
-			children = (
-				3EE1E85D2D8F01DF00681B6B /* MainViewModel.swift */,
-			);
-			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		AEF04C302D8FCD61001D3274 /* DetailDrama */ = {
@@ -396,6 +390,7 @@
 		D00927012D8EE49100A10742 /* Storage */ = {
 			isa = PBXGroup;
 			children = (
+				D09726352D918B2C00E92726 /* ModifyUserName */,
 				D00927032D8EE49E00A10742 /* ViewModel */,
 				D00927022D8EE49800A10742 /* View */,
 			);
@@ -607,6 +602,30 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
+		D09726352D918B2C00E92726 /* ModifyUserName */ = {
+			isa = PBXGroup;
+			children = (
+				D09726372D918B4F00E92726 /* View */,
+				D09726362D918B4700E92726 /* ViewModel */,
+			);
+			path = ModifyUserName;
+			sourceTree = "<group>";
+		};
+		D09726362D918B4700E92726 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		D09726372D918B4F00E92726 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				D09726382D918B5E00E92726 /* ModifyViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		D09E182F2D8D79D9004EEC6C /* Components */ = {
 			isa = PBXGroup;
 			children = (
@@ -754,6 +773,7 @@
 				D00926A02D8E748100A10742 /* StreamifyColor.swift in Sources */,
 				AEF04C342D8FCD7F001D3274 /* DramaView.swift in Sources */,
 				AEF04C362D8FCD8A001D3274 /* DramaViewController.swift in Sources */,
+				D09726392D918B5E00E92726 /* ModifyViewController.swift in Sources */,
 				3EE1E84F2D8E9F4600681B6B /* NameInputViewModel.swift in Sources */,
 				3EE1E8602D903B5700681B6B /* HorizontalMediaCell.swift in Sources */,
 				D00927AA2D8F072600A10742 /* UIView+Extension.swift in Sources */,

--- a/Streamify/Application/Coordinator/DetailCoordintaor.swift
+++ b/Streamify/Application/Coordinator/DetailCoordintaor.swift
@@ -9,11 +9,11 @@ import UIKit
 
 final class DetailCoordinator: Coordinator {
     var navigationController: UINavigationController
-    private let mediaItem: MediaItem
+    private let id: Int
 
-    init(navigationController: UINavigationController, mediaItem: MediaItem) {
+    init(navigationController: UINavigationController, id: Int) {
         self.navigationController = navigationController
-        self.mediaItem = mediaItem
+        self.id = id
     }
 
     func start() {
@@ -21,7 +21,7 @@ final class DetailCoordinator: Coordinator {
     }
 
     private func showDetailScreen() {
-        let detailVC = DramaViewController(viewModel: DramaViewModel(dramaID: mediaItem.id))
+        let detailVC = DramaViewController(viewModel: DramaViewModel(dramaID: id))
         detailVC.coordinator = self
         navigationController.pushViewController(detailVC, animated: true)
     }

--- a/Streamify/Application/Coordinator/MainCoordinator.swift
+++ b/Streamify/Application/Coordinator/MainCoordinator.swift
@@ -57,4 +57,15 @@ class MainCoordinator: Coordinator {
         commnetVC.coordinator = self
         navigationController.pushViewController(commnetVC, animated: true)
     }
+    
+    func showModifyScreen() {
+        let modifyVC = ModifyViewController()
+        modifyVC.coordinator = self
+        navigationController.pushViewController(modifyVC, animated: true)
+    }
+    
+    func popViewController() {
+        navigationController.popViewController(animated: true)
+    }
+    
 }

--- a/Streamify/Application/Coordinator/MainCoordinator.swift
+++ b/Streamify/Application/Coordinator/MainCoordinator.swift
@@ -32,8 +32,8 @@ class MainCoordinator: Coordinator {
         navigationController.pushViewController(searchVC, animated: true)
     }
     
-    func showDetail(for item: MediaItem) {
-        let coordinator = DetailCoordinator(navigationController: navigationController, mediaItem: item)
+    func showDetail(for item: Int) {
+        let coordinator = DetailCoordinator(navigationController: navigationController, id: item)
         coordinator.start()
     }
     
@@ -47,12 +47,14 @@ class MainCoordinator: Coordinator {
     func showStarRatingScreen(data: [Rate]) {
         let viewModel = StarRatingStorageViewModel()
         let starRatingVC = StarRatingStorageViewController(vm: viewModel, data: data)
+        starRatingVC.coordinator = self
         navigationController.pushViewController(starRatingVC, animated: true)
     }
     
     func showCommentScreen(data: [Comments]) {
         let viewModel = CommentViewModel()
         let commnetVC = CommentViewController(vm: viewModel, data: data)
+        commnetVC.coordinator = self
         navigationController.pushViewController(commnetVC, animated: true)
     }
 }

--- a/Streamify/Feature/Main/View/MainViewController.swift
+++ b/Streamify/Feature/Main/View/MainViewController.swift
@@ -136,7 +136,7 @@ class MainViewController: UIViewController {
             .bind(with: self) { owner, indexPath in
                 let section = owner.dataSource.sectionModels[indexPath.section]
                 let item = section.items[indexPath.item]
-                owner.coordinator?.showDetail(for: item)
+                owner.coordinator?.showDetail(for: item.id)
             }
             .disposed(by: disposeBag)
     }

--- a/Streamify/Feature/Search/View/SearchViewController.swift
+++ b/Streamify/Feature/Search/View/SearchViewController.swift
@@ -149,7 +149,7 @@ class SearchViewController: UIViewController {
         
         verticalListView.collectionView.rx.modelSelected(SearchResult.self)
             .bind(with: self) { owner, selectedItem in
-                owner.coordinator?.showDetail(for: selectedItem)
+                owner.coordinator?.showDetail(for: selectedItem.id)
             }
             .disposed(by: disposeBag)
     }

--- a/Streamify/Feature/StorageBox/Comment/View/CommentViewController.swift
+++ b/Streamify/Feature/StorageBox/Comment/View/CommentViewController.swift
@@ -15,7 +15,7 @@ final class CommentViewController: BaseViewController <CommentView, CommentViewM
     var data: [Comments]
     
     lazy var commetnsDatas = Observable.just(data)
-    weak var coordinator: DetailCoordinator?
+    weak var coordinator: MainCoordinator?
     
     init(vm: CommentViewModel, data: [Comments]) {
         self.data = data
@@ -47,10 +47,7 @@ final class CommentViewController: BaseViewController <CommentView, CommentViewM
         }.disposed(by: disposeBag)
         
         mainView.tableView.rx.modelSelected(Comments.self).bind(with: self) { owner, element in
-            
-            //print(element)
-            //coordinator?.showEpisodeList()
-            
+            owner.coordinator?.showDetail(for: element.titleID)
         }.disposed(by: disposeBag)
         
         

--- a/Streamify/Feature/StorageBox/StarRatingStorage/View/StarRatingStorageViewController.swift
+++ b/Streamify/Feature/StorageBox/StarRatingStorage/View/StarRatingStorageViewController.swift
@@ -15,7 +15,7 @@ class StarRatingStorageViewController: BaseViewController<StarRatingStorageView,
     var data: [Rate]
     
     lazy var rateDatas = Observable.just(data)
-    weak var coordinator: DetailCoordinator?
+    weak var coordinator: MainCoordinator?
     
     private let filterView = FilterButton()
     
@@ -60,10 +60,7 @@ class StarRatingStorageViewController: BaseViewController<StarRatingStorageView,
         }.disposed(by: disposeBag)
     
         mainView.verticalList.collectionView.rx.modelSelected(Rate.self).bind(with: self) { owner, element in
-            
-            print(element)
-            //coordinator?.showEpisodeList()
-            
+            owner.coordinator?.showDetail(for: element.titleID)
         }.disposed(by: disposeBag)
     }
 

--- a/Streamify/Feature/StorageBox/Storage/ModifyUserName/View/ModifyViewController.swift
+++ b/Streamify/Feature/StorageBox/Storage/ModifyUserName/View/ModifyViewController.swift
@@ -1,0 +1,102 @@
+//
+//  ModifyViewController.swift
+//  Streamify
+//
+//  Created by youngkyun park on 3/24/25.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+final class ModifyViewController: UIViewController {
+    
+    weak var coordinator: MainCoordinator?
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "안녕하세요!\n변경하실 이름을 입력해주세요."
+        label.font = UIFont.systemFont(ofSize: 22, weight: .bold)
+        label.numberOfLines = 2
+        label.textAlignment = .left
+        label.textColor = .setStreamifyColor(.baseWhite)
+        return label
+    }()
+    
+    private let nameTextField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "이름 입력"
+        textField.borderStyle = .roundedRect
+        textField.textAlignment = .left
+        return textField
+    }()
+    
+    private let nextButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("확인", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.backgroundColor = .lightGray
+        button.layer.cornerRadius = 10
+        button.isEnabled = false
+        return button
+    }()
+    
+    private let disposeBag = DisposeBag()
+    private let viewModel = NameInputViewModel()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        bindViewModel()
+    }
+    
+    private func setupUI() {
+        
+        view.addSubview(titleLabel)
+        view.addSubview(nameTextField)
+        view.addSubview(nextButton)
+        
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(50)
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(20)
+        }
+        
+        nameTextField.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(20)
+            make.leading.trailing.equalToSuperview().inset(30)
+            make.height.equalTo(44)
+        }
+        
+        nextButton.snp.makeConstraints { make in
+            make.bottom.equalTo(view.safeAreaLayoutGuide).inset(30)
+            make.horizontalEdges.equalToSuperview().inset(30)
+            make.height.equalTo(50)
+        }
+    }
+    
+    private func bindViewModel() {
+        nameTextField.rx.text.orEmpty
+            .bind(to: viewModel.inputName)
+            .disposed(by: disposeBag)
+        
+        viewModel.isValidName
+            .drive(nextButton.rx.isEnabled)
+            .disposed(by: disposeBag)
+        
+        viewModel.isValidName
+            .map { $0 ? UIColor.systemBlue : UIColor.lightGray }
+            .drive(nextButton.rx.backgroundColor)
+            .disposed(by: disposeBag)
+        
+        nextButton.rx.tap
+            .bind { [weak self] in
+                guard let self = self else { return }
+                
+                UserDefaults.standard.set(nameTextField.text, forKey: "userName")
+                self.coordinator?.popViewController()
+            }
+            .disposed(by: disposeBag)
+    }
+    
+}

--- a/Streamify/Feature/StorageBox/Storage/View/StorageViewController.swift
+++ b/Streamify/Feature/StorageBox/Storage/View/StorageViewController.swift
@@ -40,6 +40,8 @@ final class StorageViewController: BaseViewController<StorageView, StorageViewMo
         }
     )
     
+    let rightBarButton = UIBarButtonItem(image: UIImage(systemName: "person.crop.circle.fill"), style: .plain, target: nil, action: nil)
+    
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -78,6 +80,11 @@ final class StorageViewController: BaseViewController<StorageView, StorageViewMo
             
         }.disposed(by: disposeBag)
         
+        rightBarButton.rx.tap.bind(with: self) { owner, _ in
+            
+            owner.coordinator?.showModifyScreen()
+            
+        }.disposed(by: disposeBag)
         
         output.setSetcion.bind(to: mainView.storageList.collectionView.rx.items(dataSource: dataSource)).disposed(by: disposeBag)
 
@@ -142,6 +149,7 @@ extension StorageViewController {
     private func setupNavigation() {
         let title = "보관함"
         navigationItem.title = title
+        navigationItem.rightBarButtonItem = rightBarButton
         navigationItem.backButtonTitle = ""
     }
     

--- a/Streamify/Feature/StorageBox/Storage/View/StorageViewController.swift
+++ b/Streamify/Feature/StorageBox/Storage/View/StorageViewController.swift
@@ -67,8 +67,20 @@ final class StorageViewController: BaseViewController<StorageView, StorageViewMo
         let output = viewModel.transform(input: input)
         
         
+        mainView.storageList.collectionView.rx.modelSelected(StorageSectionItem.self).bind(with: self) { owner, element in
+            
+            switch element {
+            case .firstSection(let data), .secondSection(let data), .thirdSection(let data):
+                owner.coordinator?.showDetail(for: data.titleID)
+            }
+            
+            
+            
+        }.disposed(by: disposeBag)
+        
         
         output.setSetcion.bind(to: mainView.storageList.collectionView.rx.items(dataSource: dataSource)).disposed(by: disposeBag)
+
         
         output.goToStarRating.asDriver(onErrorJustReturn: [])
             .drive(with: self) { owner, data in


### PR DESCRIPTION
1. 상세화면 연결
2. 프로필 화면 추가

온보딩 코디네이터를 활용해서 뷰를 재사용해보려했으나, 메인 코디네이터에서는 온보딩 코딩네이터 관련해서 프로토콜 타입 연결 및 루트뷰를 변경해줘야하는 이슈가 있어 우선 별도의 뷰로 구성했습니다.
재사용 가능에 대해서는 조금 고민해보고 리팩해보도록 하겠습니다.